### PR TITLE
roy.gal

### DIFF
--- a/src/main/java/use_case/logout/LogoutInteractor.java
+++ b/src/main/java/use_case/logout/LogoutInteractor.java
@@ -30,22 +30,16 @@ public class LogoutInteractor implements LogoutInputBoundary {
      */
     @Override
     public void execute(final LogoutInputData logoutInputData) {
-        // * get the username out of the input data,
-        // * set the username to null in the DAO
-        // * instantiate the `LogoutOutputData`,which needs to contain username.
-        // * tell the presenter to prepare a success view.
         final String username = logoutInputData.getUsername();
 
-        // I (Victor) added this fail condition but unsure if needed
-        if (username == null) {
+        // If the username is null, you can log a message or handle the error gracefully instead of triggering a failure
+        if (username == null || username.isEmpty()) {
             logoutPresenter.prepareFailView("Username not found.");
         }
         else {
+            // Proceed with logging out
             userDataAccessObject.setCurrentUsername(null);
 
-            // I'm pretty sure the useCaseFailed argument is supposed to be
-            // false unless I interpreted it wrong
-            // Documenting here just in case (delete if all tests pass)
             final LogoutOutputData logoutOutputData = new LogoutOutputData(username, false);
             logoutPresenter.prepareSuccessView(logoutOutputData);
         }

--- a/src/main/java/view/HomeView.java
+++ b/src/main/java/view/HomeView.java
@@ -5,7 +5,6 @@ import java.awt.Component;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.List;
-import java.util.Objects;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -257,7 +256,8 @@ public class HomeView extends JPanel implements PropertyChangeListener {
                         updateTable(currentState.getListings(), currentState.getWishlist());
                     }
                     catch (NumberFormatException e) {
-                        JOptionPane.showMessageDialog(null, "Invalid input. Please enter a number between 1 and 10.");
+                        JOptionPane.showMessageDialog(HomeView.this,
+                                "Invalid input. Please enter a number between 1 and 10.");
                     }
                 }
         );

--- a/src/main/java/view/LoginView.java
+++ b/src/main/java/view/LoginView.java
@@ -152,7 +152,6 @@ public class LoginView extends JPanel implements ActionListener, PropertyChangeL
     public void propertyChange(PropertyChangeEvent evt) {
         final LoginState state = (LoginState) evt.getNewValue();
         setFields(state);
-        loginController.error(LoginView.this, state.getLoginError());
     }
 
     public void setBackToSignupController(BackToSignupController backToSignupController) {

--- a/src/main/java/view/SellView.java
+++ b/src/main/java/view/SellView.java
@@ -187,11 +187,11 @@ public class SellView extends JPanel implements PropertyChangeListener {
         }
         else if (evt.getPropertyName().equals("not sold")) {
             final SellState state = (SellState) evt.getNewValue();
-            JOptionPane.showMessageDialog(null, state.getSellError());
+            JOptionPane.showMessageDialog(SellView.this, state.getSellError());
         }
         else if (evt.getPropertyName().equals("listed for sale")) {
             final SellState state = (SellState) evt.getNewValue();
-            JOptionPane.showMessageDialog(null, createSellMessage(priceInputField.getText(),
+            JOptionPane.showMessageDialog(SellView.this, createSellMessage(priceInputField.getText(),
                     bookIDInputField.getText(), state.getUsername()));
         }
     }

--- a/src/main/java/view/SignupView.java
+++ b/src/main/java/view/SignupView.java
@@ -214,7 +214,7 @@ public class SignupView extends JPanel implements ActionListener, PropertyChange
     public void propertyChange(PropertyChangeEvent evt) {
         final SignupState state = (SignupState) evt.getNewValue();
         if (state.getSignupError() != null) {
-            JOptionPane.showMessageDialog(this, state.getSignupError());
+            JOptionPane.showMessageDialog(SignupView.this, state.getSignupError());
         }
     }
 


### PR DESCRIPTION
Centered error messages in different files (parenrComponent parameter of JOptionPane.showMessageDialog() should not be null). Fixed the empty error message after pressing the logout button, and changed LogoutInteractor logic (added non-empty username statement check).